### PR TITLE
Produce drops to world if harvesting fails

### DIFF
--- a/src/main/java/org/terasology/simpleFarming/systems/FarmingAuthoritySystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/FarmingAuthoritySystem.java
@@ -364,7 +364,11 @@ public class FarmingAuthoritySystem extends BaseComponentSystem {
                 EntityRef produceItem = plantProduceComponent.produceItem;
                 plantProduceComponent.produceItem = EntityRef.NULL;
                 target.saveComponent(plantProduceComponent);
-                inventoryManager.giveItem(harvestingEntity, target, produceItem);
+                if (!inventoryManager.giveItem(harvestingEntity, target, produceItem) && target.hasComponent(BlockComponent.class)) {
+                    Vector3f position = target.getComponent(BlockComponent.class).getPosition().toVector3f().add(0, 0.5f, 0);
+                    produceItem.send(new DropItemEvent(position));
+                    produceItem.send(new ImpulseEvent(random.nextVector3f(15.0f)));
+                }
                 target.send(new OnPlantHarvest());
                 event.consume();
             }

--- a/src/main/java/org/terasology/simpleFarming/systems/TreeAuthoritySystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/TreeAuthoritySystem.java
@@ -247,7 +247,16 @@ public class TreeAuthoritySystem extends BaseComponentSystem {
         if (!event.isConsumed() && instigator.hasComponent(InventoryComponent.class)) {
             EntityRef fruitItem = entityManager.create(creationComponent.fruitPrefab);
             if (fruitItem != EntityRef.NULL) {
-                inventoryManager.giveItem(instigator, instigator, fruitItem);
+                if (!inventoryManager.giveItem(instigator, instigator, fruitItem)) {
+                    Vector3f position = blockComponent.getPosition().toVector3f();
+                    if (worldProvider.getBlock(new Vector3f(position).add(0, -1f, 0)).isReplacementAllowed()) {
+                        position.add(0, -0.5f, 0);
+                    } else {
+                        position.add(0, 0.5f, 0);
+                    }
+                    fruitItem.send(new DropItemEvent(position));
+                    fruitItem.send(new ImpulseEvent(random.nextVector3f(15.0f)));
+                }
                 event.consume();
 
                 // find controller for this fruit


### PR DESCRIPTION
This closes #4.

Previously, if your inventory was full, harvesting would cause plant ungrowth, but you wouldn't receive the item in your inventory. This also occurs with the newly added fruit trees, so I've fixed both of these instances.

### How to Test

Fill your inventory up with a non-stackable item (I used `give pickaxe`) and harvest a fully grown plant or fruit tree. The fruit or produce should drop into the world instead of vanishing into thin air. 🙂