### PR TITLE
Add tests for `BushAuthoritySystem`

### DIFF
--- a/assets/blocks/Bushes/Testing/MatureTestBush.block
+++ b/assets/blocks/Bushes/Testing/MatureTestBush.block
@@ -1,0 +1,5 @@
+{
+  "basedOn": "SimpleFarming:BaseBush",
+  "displayName": "Mature Test Bush",
+  "tile": "SimpleFarming:MatureTestBush"
+}

--- a/assets/blocks/Bushes/Testing/TestBush.block
+++ b/assets/blocks/Bushes/Testing/TestBush.block
@@ -1,0 +1,5 @@
+{
+  "basedOn": "SimpleFarming:BaseBush",
+  "displayName": "Test Bush",
+  "tile": "SimpleFarming:TestBush"
+}

--- a/assets/prefabs/Testing/TestProduce.prefab
+++ b/assets/prefabs/Testing/TestProduce.prefab
@@ -1,0 +1,9 @@
+{
+  "parent": "engine:iconItem",
+  "DisplayName": {
+    "name": "Test Produce"
+  },
+  "Item": {
+    "stackId": "SimpleFarming:TestProduce"
+  }
+}

--- a/assets/prefabs/Testing/TestSeed.prefab
+++ b/assets/prefabs/Testing/TestSeed.prefab
@@ -1,0 +1,27 @@
+{
+  "parent": "engine:iconItem",
+  "DisplayName": {
+    "name": "Test Seed"
+  },
+  "Item": {
+    "icon": "SimpleFarming:TestSeed",
+    "stackId": "Test Seed"
+  },
+  "SeedDefinition": {},
+  "BushDefinition": {
+    "growthStages": {
+      "SimpleFarming:TestBush:engine:halfblock": {
+        "minTime": 500,
+        "maxTime": 500
+      },
+      "SimpleFarming:TestBush": {
+        "minTime": 500,
+        "maxTime": 500
+      },
+      "SimpleFarming:MatureTestBush": {}
+    },
+    "seed": "SimpleFarming:TestSeed",
+    "produce": "SimpleFarming:TestProduce",
+    "sustainable": true
+  }
+}

--- a/module.txt
+++ b/module.txt
@@ -11,7 +11,7 @@
              "minVersion" : "1.0.0"
          },
          {
-             "id": "ModuleTestingEnvironment",
+             "id" : "ModuleTestingEnvironment",
              "minVersion" : "0.1.0"
          }
      ],

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "SimpleFarming",
-    "version" : "2.0.0-SNAPSHOT",
+    "version" : "2.0.1-SNAPSHOT",
     "author" : "Josharias, Mandar Juvekar, patrick Wang, Harry Wang, mdj117, SufurElite, He Who Shall Not Be Named (VaibhavBajaj), andriii25, smsunarto, DhananjayGarg, Jay Gupta",
 
     "displayName" : "Simple Farming",
@@ -9,6 +9,10 @@
          {
              "id" : "Core",
              "minVersion" : "1.0.0"
+         },
+         {
+             "id": "ModuleTestingEnvironment",
+             "minVersion" : "0.1.0"
          }
      ],
     "isServerSideOnly" : false

--- a/src/main/java/org/terasology/simpleFarming/systems/BushAuthoritySystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/BushAuthoritySystem.java
@@ -189,6 +189,7 @@ public class BushAuthoritySystem extends BaseComponentSystem {
                 } else {
                     entity.send(new DoDestroyPlant());
                     worldProvider.setBlock(bushComponent.position, blockManager.getBlock(BlockManager.AIR_ID));
+                    entity.destroy();
                 }
                 event.consume();
             }

--- a/src/test/java/org/terasology/simpleFarming/systems/BushAuthoritySystemTest.java
+++ b/src/test/java/org/terasology/simpleFarming/systems/BushAuthoritySystemTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.simpleFarming.systems;
+
+import org.junit.Test;
+import org.terasology.simpleFarming.testing.SingleBushTestingEnvironment;
+
+public class BushAuthoritySystemTest extends SingleBushTestingEnvironment {
+
+    @Test
+    public void bushShouldGrowInOrder() {
+        for (int i = 0; i < getFinalGrowthStageIndex(); i++) {
+            assertBushInStage(i);
+            waitForGrowth();
+        }
+    }
+
+    @Test
+    public void harvestingSustainableBushShouldResetGrowthAndDropProduce() {
+        waitUntilHarvestable();
+        assertActionDropsProduce(this::harvestBush);
+        assertBushInStage(getFinalGrowthStageIndex() - 1);
+    }
+
+    @Test
+    public void harvestingUnsustainableBushShouldDestroyBushAndDropBothSeedsAndProduce() {
+        makeBushUnsustainable();
+        waitUntilHarvestable();
+        assertActionDropsSeedsAndProduce(this::harvestBush);
+        assertBushDestroyed();
+    }
+
+    @Test
+    public void destroyingMatureBushShouldDropSeeds() {
+        waitUntilHarvestable();
+        assertActionDropsSeeds(this::destroyBush);
+        assertBushDestroyed();
+    }
+}

--- a/src/test/java/org/terasology/simpleFarming/testing/SingleBushTestingEnvironment.java
+++ b/src/test/java/org/terasology/simpleFarming/testing/SingleBushTestingEnvironment.java
@@ -174,21 +174,21 @@ public class SingleBushTestingEnvironment extends ModuleTestingEnvironment {
         assertEquals(air, worldProvider.getBlock(BUSH_LOCATION));
     }
 
-    protected final void assertActionDropsSeeds(Runnable block) {
-        assertActionDropsPrefabs(block, component.seed);
+    protected final void assertActionDropsSeeds(Runnable action) {
+        assertActionDropsPrefabs(action, component.seed);
     }
 
-    protected final void assertActionDropsProduce(Runnable block) {
-        assertActionDropsPrefabs(block, component.produce);
+    protected final void assertActionDropsProduce(Runnable action) {
+        assertActionDropsPrefabs(action, component.produce);
     }
 
-    protected final void assertActionDropsSeedsAndProduce(Runnable block) {
-        assertActionDropsPrefabs(block, component.seed, component.produce);
+    protected final void assertActionDropsSeedsAndProduce(Runnable action) {
+        assertActionDropsPrefabs(action, component.seed, component.produce);
     }
 
-    private void assertActionDropsPrefabs(Runnable block, String... prefabs) {
+    private void assertActionDropsPrefabs(Runnable action, String... prefabs) {
         final TestEventReceiver<DropItemEvent> dropSpy = new TestEventReceiver<>(getHostContext(), DropItemEvent.class);
-        block.run();
+        action.run();
         for (String prefab : prefabs) {
             assertListContainsEntityFromPrefab(dropSpy.getEntityRefs(), prefab);
         }

--- a/src/test/java/org/terasology/simpleFarming/testing/SingleBushTestingEnvironment.java
+++ b/src/test/java/org/terasology/simpleFarming/testing/SingleBushTestingEnvironment.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.simpleFarming.testing;
+
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.common.ActivateEvent;
+import org.terasology.logic.health.DestroyEvent;
+import org.terasology.logic.health.EngineDamageTypes;
+import org.terasology.logic.inventory.events.DropItemEvent;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.math.geom.Vector3i;
+import org.terasology.moduletestingenvironment.ModuleTestingEnvironment;
+import org.terasology.moduletestingenvironment.TestEventReceiver;
+import org.terasology.simpleFarming.components.BushDefinitionComponent;
+import org.terasology.world.BlockEntityRegistry;
+import org.terasology.world.WorldProvider;
+import org.terasology.world.block.Block;
+import org.terasology.world.block.BlockManager;
+
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Test environment specific to the {@code SimpleFarming} module.
+ * <p>
+ * Each test run in this environment has access to a single bush, based on a test-specific prefab.
+ * The methods on this class can be used to manipulate and make assertions about this bush.
+ */
+public class SingleBushTestingEnvironment extends ModuleTestingEnvironment {
+    private static final Vector3i BUSH_LOCATION = Vector3i.zero();
+    private static final String BUSH_SEED_PREFAB = "SimpleFarming:TestSeed";
+
+    private EntityManager entityManager;
+    private WorldProvider worldProvider;
+
+    private Block air;
+    private Block dirt;
+
+    private EntityRef bush;
+    private BushDefinitionComponent component;
+
+    @Override
+    public Set<String> getDependencies() {
+        return Collections.singleton("SimpleFarming");
+    }
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+
+        bindAbstractVariables();
+        buildTestEnvironment();
+        bindConcreteVariables();
+    }
+
+    private void bindAbstractVariables() {
+        entityManager = getHostContext().get(EntityManager.class);
+        worldProvider = getHostContext().get(WorldProvider.class);
+
+        BlockManager blockManager = getHostContext().get(BlockManager.class);
+        air = blockManager.getBlock("engine:air");
+        dirt = blockManager.getBlock("core:dirt");
+    }
+
+    private void buildTestEnvironment() {
+        final Vector3i belowTargetPosition = new Vector3i(BUSH_LOCATION).add(Vector3i.down());
+
+        forceAndSetBlock(belowTargetPosition, dirt);
+        forceAndSetBlock(BUSH_LOCATION, air);
+        plantSeed();
+    }
+
+    private void forceAndSetBlock(Vector3i position, Block material) {
+        forceAndWaitForGeneration(position);
+        worldProvider.setBlock(position, material);
+    }
+
+    private void plantSeed() {
+        final EntityRef seed = entityManager.create(BUSH_SEED_PREFAB);
+        final Vector3f dirtPosition = new Vector3f(BUSH_LOCATION.toVector3f()).add(Vector3f.down());
+        final EntityRef target = entityManager.create(new LocationComponent(dirtPosition));
+        seed.send(new ActivateEvent(
+                target,          // target
+                EntityRef.NULL,  // instigator
+                null,            // origin
+                null,            // direction
+                dirtPosition,    // hit position
+                Vector3f.up(),   // hit normal
+                0                // activation id
+        ));
+    }
+
+    private void bindConcreteVariables() {
+        BlockEntityRegistry blockEntityRegistry = getHostContext().get(BlockEntityRegistry.class);
+        bush = blockEntityRegistry.getExistingBlockEntityAt(BUSH_LOCATION);
+        component = bush.getComponent(BushDefinitionComponent.class);
+    }
+
+    protected final int getFinalGrowthStageIndex() {
+        return component.stages.length - 1;
+    }
+
+    protected final void makeBushUnsustainable() {
+        component.sustainable = false;
+    }
+
+    /**
+     * Harvests the test bush.
+     * <p>
+     * The entity doing the harvesting has no inventory, so produce drops should spawn into the
+     * world (and therefore be detectable via {@link #assertActionDropsProduce(Runnable)}).
+     */
+    protected final void harvestBush() {
+        bush.send(new ActivateEvent(
+                bush,                    // target
+                entityManager.create(),  // instigator
+                null,                    // origin
+                null,                    // direction
+                null,                    // hit position
+                null,                    // hit normal
+                0                        // activation id
+        ));
+    }
+
+    protected final void destroyBush() {
+        bush.send(new DestroyEvent(
+                EntityRef.NULL,                // instigator
+                EntityRef.NULL,                // direct cause
+                EngineDamageTypes.DIRECT.get() // damage type
+        ));
+    }
+
+    protected final void waitForGrowth() {
+        final int startStage = component.currentStage;
+        runWhile(() -> component.currentStage == startStage);
+    }
+
+    protected final void waitUntilHarvestable() {
+        runUntil(() -> (component.currentStage == getFinalGrowthStageIndex()));
+    }
+
+    /**
+     * Asserts that the test bush is in the expected growth stage.
+     * <p>
+     * This checks both that the {@link BushDefinitionComponent#currentStage} field has the correct
+     * value, and that the block used is correct.
+     */
+    protected final void assertBushInStage(int stage) {
+        assertEquals(stage, component.currentStage);
+        assertEquals(component.stages[stage].block, worldProvider.getBlock(component.position));
+    }
+
+    /** Asserts that both the bush block and the bush entity have been destroyed. */
+    protected final void assertBushDestroyed() {
+        assertFalse(bush.exists());
+        assertEquals(air, worldProvider.getBlock(BUSH_LOCATION));
+    }
+
+    protected final void assertActionDropsSeeds(Runnable block) {
+        assertActionDropsPrefabs(block, component.seed);
+    }
+
+    protected final void assertActionDropsProduce(Runnable block) {
+        assertActionDropsPrefabs(block, component.produce);
+    }
+
+    protected final void assertActionDropsSeedsAndProduce(Runnable block) {
+        assertActionDropsPrefabs(block, component.seed, component.produce);
+    }
+
+    private void assertActionDropsPrefabs(Runnable block, String... prefabs) {
+        final TestEventReceiver<DropItemEvent> dropSpy = new TestEventReceiver<>(getHostContext(), DropItemEvent.class);
+        block.run();
+        for (String prefab : prefabs) {
+            assertListContainsEntityFromPrefab(dropSpy.getEntityRefs(), prefab);
+        }
+    }
+
+    private static void assertListContainsEntityFromPrefab(List<EntityRef> items, String prefab) {
+        assertTrue(String.format("Operation did not drop %s", prefab),
+                items.stream().anyMatch(item -> entityIsFromPrefab(item, prefab)));
+    }
+
+    private static boolean entityIsFromPrefab(EntityRef entity, String prefab) {
+        return entity.getParentPrefab().getName().equals(prefab);
+    }
+
+}

--- a/src/test/java/org/terasology/simpleFarming/testing/SingleBushTestingEnvironment.java
+++ b/src/test/java/org/terasology/simpleFarming/testing/SingleBushTestingEnvironment.java
@@ -95,7 +95,7 @@ public class SingleBushTestingEnvironment extends ModuleTestingEnvironment {
 
     private void plantSeed() {
         final EntityRef seed = entityManager.create(BUSH_SEED_PREFAB);
-        final Vector3f dirtPosition = new Vector3f(BUSH_LOCATION.toVector3f()).add(Vector3f.down());
+        final Vector3f dirtPosition = BUSH_LOCATION.toVector3f().add(Vector3f.down());
         final EntityRef target = entityManager.create(new LocationComponent(dirtPosition));
         seed.send(new ActivateEvent(
                 target,          // target


### PR DESCRIPTION
### Contains

Automated tests for `BushAuthoritySystem`.

Also one minor bug fix: It appears that after harvesting an unsustainable bush, and thus destroying it, the bush entity continues to exist.  I'm not sure how big a deal this is, but I added a line destroying the entity just to be sure.  Someone with a better understanding of how entity destruction works should probably take a look at that.

### How to test

Run the test suite.

To be safe, you could also boot up the game, give yourself a whole bunch of potatoes (the only unsustainable bush currently in the module), plant them, and harvest them.  I did this with no unexpected effects, from which I conclude that my bug fix is at worst harmless.

### Outstanding before merging

Nothing.

### Future plans

With this PR and PR #64, we will have reasonable test coverage for two of the three systems in the module.  After this, I intend to add tests for the final system (`VineAuthoritySystem`), and then refactor the test code for all three systems to clean it up and remove the duplication arising from treating the tests for each system independently in the first pass.