### PR TITLE
Enforce substance matters optional dependency

### DIFF
--- a/src/main/java/org/terasology/simpleFarming/systems/TintModifierSystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/TintModifierSystem.java
@@ -12,7 +12,7 @@ import org.terasology.simpleFarming.events.ModifyTint;
 import org.terasology.substanceMatters.components.MaterialCompositionComponent;
 import org.terasology.substanceMatters.components.MaterialItemComponent;
 
-@RegisterSystem(RegisterMode.AUTHORITY)
+@RegisterSystem(value = RegisterMode.AUTHORITY, requiresOptional = {"SubstanceMatters"})
 public class TintModifierSystem extends BaseComponentSystem {
 
     @ReceiveEvent


### PR DESCRIPTION
Added a check to the Register System annotation to ensure that the TintModifierSystem is only registered when SubstanceMatters is activated.