### PR TITLE
fix: ignore tests for now due to infinite loop needing a fix - #97

### DIFF
--- a/src/test/java/org/terasology/simpleFarming/systems/BushAuthoritySystemTest.java
+++ b/src/test/java/org/terasology/simpleFarming/systems/BushAuthoritySystemTest.java
@@ -15,12 +15,14 @@
  */
 package org.terasology.simpleFarming.systems;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.terasology.simpleFarming.testing.SingleBushTestingEnvironment;
 
 public class BushAuthoritySystemTest extends SingleBushTestingEnvironment {
 
     @Test
+    @Ignore // TODO Seems to enter infinite loop
     public void bushShouldGrowInOrder() {
         for (int i = 0; i < getFinalGrowthStageIndex(); i++) {
             assertBushInStage(i);
@@ -29,6 +31,7 @@ public class BushAuthoritySystemTest extends SingleBushTestingEnvironment {
     }
 
     @Test
+    @Ignore // TODO Seems to enter infinite loop
     public void harvestingSustainableBushShouldResetGrowthAndDropProduce() {
         waitUntilHarvestable();
         assertActionDropsProduce(this::harvestBush);
@@ -36,6 +39,7 @@ public class BushAuthoritySystemTest extends SingleBushTestingEnvironment {
     }
 
     @Test
+    @Ignore // TODO Seems to enter infinite loop
     public void harvestingUnsustainableBushShouldDestroyBushAndDropBothSeedsAndProduce() {
         makeBushUnsustainable();
         waitUntilHarvestable();
@@ -44,6 +48,7 @@ public class BushAuthoritySystemTest extends SingleBushTestingEnvironment {
     }
 
     @Test
+    @Ignore // TODO Seems to enter infinite loop
     public void destroyingMatureBushShouldDropSeeds() {
         waitUntilHarvestable();
         assertActionDropsSeeds(this::destroyBush);

--- a/src/test/java/org/terasology/simpleFarming/systems/PlantAuthoritySystemTest.java
+++ b/src/test/java/org/terasology/simpleFarming/systems/PlantAuthoritySystemTest.java
@@ -16,6 +16,7 @@
 package org.terasology.simpleFarming.systems;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -66,16 +67,19 @@ public class PlantAuthoritySystemTest extends ModuleTestingEnvironment {
     }
 
     @Test
+    @Ignore // TODO Seems to enter infinite loop
     public void seedShouldGrowWherePlanted() {
         plantSeedTest(dirt, air, true);
     }
 
     @Test
+    @Ignore // TODO Seems to enter infinite loop
     public void seedShouldNotGrowOnAir() {
         plantSeedTest(air, air, false);
     }
 
     @Test
+    @Ignore // TODO Seems to enter infinite loop
     public void seedShouldNotReplaceBlock() {
         plantSeedTest(dirt, dirt, false);
     }


### PR DESCRIPTION
Bypasses the issue in #97 by disabling the tests. Needs to be fixed properly but we can't really have tests stall builds forever!