### PR TITLE
Add check for Genome optional dependency

### DIFF
--- a/src/main/java/org/terasology/simpleFarming/systems/GenomeAuthoritySystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/GenomeAuthoritySystem.java
@@ -52,7 +52,7 @@ import javax.annotation.Nullable;
 /**
  * System managing genetics of all plants
  */
-@RegisterSystem(RegisterMode.AUTHORITY)
+@RegisterSystem(value = RegisterMode.AUTHORITY, requiresOptional = {"Genome"})
 public class GenomeAuthoritySystem extends BaseComponentSystem {
     @In
     private GenomeRegistry genomeRegistry;

--- a/src/main/java/org/terasology/simpleFarming/systems/GenomeAuthoritySystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/GenomeAuthoritySystem.java
@@ -44,8 +44,6 @@ import org.terasology.simpleFarming.events.ModifyFilling;
 import org.terasology.simpleFarming.events.ModifyTint;
 import org.terasology.simpleFarming.events.ProduceCreated;
 import org.terasology.simpleFarming.events.TransferGenomeEvent;
-import org.terasology.substanceMatters.components.MaterialCompositionComponent;
-import org.terasology.substanceMatters.components.MaterialItemComponent;
 import org.terasology.utilities.random.FastRandom;
 import org.terasology.world.WorldProvider;
 


### PR DESCRIPTION
Fixes the following error that was logged during the week long playtest server running `MetalRenegades` which includes `SimpleFarming` 
```
10:32:08.121 [main] ERROR o.t.engine.ComponentSystemManager - Failed to load system SimpleFarming:GenomeAuthoritySystem
java.lang.NoClassDefFoundError: org/terasology/genome/breed/mutator/GeneMutator
        at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
        at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3137)
        at java.base/java.lang.Class.getConstructor0(Class.java:3342)
        at java.base/java.lang.Class.newInstance(Class.java:556)
        at org.terasology.engine.ComponentSystemManager.loadSystems(ComponentSystemManager.java:99)
        at org.terasology.engine.modes.loadProcesses.RegisterSystems.step(RegisterSystems.java:54)
        at org.terasology.engine.modes.StateLoading.update(StateLoading.java:237)
        at org.terasology.engine.TerasologyEngine.tick(TerasologyEngine.java:472)
        at org.terasology.engine.TerasologyEngine.mainLoop(TerasologyEngine.java:435)
        at org.terasology.engine.TerasologyEngine.run(TerasologyEngine.java:411)
        at org.terasology.engine.Terasology.main(Terasology.java:155)
```

The optional dependency of Genome is checked before loading the system, rather than relying on an error to cause the system to fail to load. 

### How to test :
- Create a game with `SimpleFarming` activated but without `Genome` 
- This game should not log an error when trying to load the `GenomeAuthoritySystem`, but should ignore this system altogether
- Create a game with both `SimpleFarming` and `Genome` enabled
- The `GenomeAuthoritySystem` should load successfully, this can be verified by running the `HeldGenomeCheck` after harvesting a bush and holding the seed in your hand. 