### PR TITLE
fix(#116): Hard crash destroying Joshaberry Bush due to missing berryseed.

### DIFF
--- a/assets/atlas/SimpleFarming.atlas
+++ b/assets/atlas/SimpleFarming.atlas
@@ -5,7 +5,7 @@
         "tileSize":[32, 32],
         "gridDimensions":[8, 8],
         "tileNames":[
-            "TestBerrySeed", "TestBerry", "GrowthCan", "UnGrowthCan", "", "", "", "",
+            "TestBerrySeed", "TestBerry", "GrowthCan", "UnGrowthCan", "Berryseed", "", "", "",
             "", "", "", "", "", "", "", "",
             "", "", "", "", "", "", "", "",
             "", "", "", "", "", "", "", "",

--- a/assets/atlas/SimpleFarming.atlas
+++ b/assets/atlas/SimpleFarming.atlas
@@ -5,7 +5,7 @@
         "tileSize":[32, 32],
         "gridDimensions":[8, 8],
         "tileNames":[
-            "TestBerrySeed", "TestBerry", "GrowthCan", "UnGrowthCan", "berryseed", "", "", "",
+            "BerrySeed", "Berry", "GrowthCan", "UnGrowthCan", "", "", "", "",
             "", "", "", "", "", "", "", "",
             "", "", "", "", "", "", "", "",
             "", "", "", "", "", "", "", "",

--- a/assets/atlas/SimpleFarming.atlas
+++ b/assets/atlas/SimpleFarming.atlas
@@ -5,7 +5,7 @@
         "tileSize":[32, 32],
         "gridDimensions":[8, 8],
         "tileNames":[
-            "TestBerrySeed", "TestBerry", "GrowthCan", "UnGrowthCan", "Berryseed", "", "", "",
+            "BerrySeed", "Berry", "GrowthCan", "UnGrowthCan", "", "", "", "",
             "", "", "", "", "", "", "", "",
             "", "", "", "", "", "", "", "",
             "", "", "", "", "", "", "", "",

--- a/assets/atlas/SimpleFarming.atlas
+++ b/assets/atlas/SimpleFarming.atlas
@@ -5,7 +5,7 @@
         "tileSize":[32, 32],
         "gridDimensions":[8, 8],
         "tileNames":[
-            "TestBerrySeed", "TestBerry", "GrowthCan", "UnGrowthCan", "", "", "", "",
+            "TestBerrySeed", "TestBerry", "GrowthCan", "UnGrowthCan", "berryseed", "", "", "",
             "", "", "", "", "", "", "", "",
             "", "", "", "", "", "", "", "",
             "", "", "", "", "", "", "", "",

--- a/assets/prefabs/Testing/TestSeed.prefab
+++ b/assets/prefabs/Testing/TestSeed.prefab
@@ -4,7 +4,7 @@
     "name": "Test Seed"
   },
   "Item": {
-    "icon": "SimpleFarming:SimpleFarming#TestBerrySeed",
+    "icon": "SimpleFarming:SimpleFarming#BerrySeed",
     "stackId": "Test Seed"
   },
   "SeedDefinition": {},


### PR DESCRIPTION
berryseed added to atlas. The game would hard crash when destroying a Joshaberry Bush due to missing berryseed reference.

### Bug:
Fixes #116 

### Known Issue(s):
After destroying a Joshaberry Bush, its seed will be invisible/transparent and not visible to the player if it is on the
ground. However, when having collected 2 or more, a number will appear in the inventory and when hovered over the name will be displayed.
When planting the berry bush seed it will take much longer than other bushes to grow.

### Test Configuration(s):
displayVersion=alpha-20
engineVersion=5.1.0-SNAPSHOT
Java: 11.0.11 in C:\Program Files\AdoptOpenJDK\jdk-11.0.11.9-hotspot
Java VM: OpenJDK 64-Bit Server VM, version: 11.0.11+9
OS: Windows 8.1, arch: amd64, version: 6.3
GFX: nVidia GTX 1050Ti Driver 471.11
SimpleFarming-2.2.0-SNAPSHOT