### PR TITLE
feat: split GenomeAuthoritySystem based on modules

### DIFF
--- a/src/main/java/org/terasology/simpleFarming/systems/GenomeCraftingExtensionAuthoritySystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/GenomeCraftingExtensionAuthoritySystem.java
@@ -6,6 +6,7 @@ package org.terasology.simpleFarming.systems;
 import org.terasology.crafting.events.OnRecipeCrafted;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.event.ReceiveEvent;
+import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
 import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.registry.In;
@@ -19,7 +20,7 @@ import org.terasology.genome.system.SimpleGenomeManager;
  * This component system is only loaded if both "Genome" and "BasicCrafting" are enabled.
  */
 @RegisterSystem(RegisterMode.AUTHORITY)
-public class GenomeCraftingExtensionAuthoritySystem {
+public class GenomeCraftingExtensionAuthoritySystem extends BaseComponentSystem {
 
     @In
     private GenomeRegistry genomeRegistry;

--- a/src/main/java/org/terasology/simpleFarming/systems/GenomeCraftingExtensionAuthoritySystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/GenomeCraftingExtensionAuthoritySystem.java
@@ -1,0 +1,49 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.simpleFarming.systems;
+
+import org.terasology.crafting.events.OnRecipeCrafted;
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.entitySystem.event.ReceiveEvent;
+import org.terasology.engine.entitySystem.systems.RegisterMode;
+import org.terasology.engine.entitySystem.systems.RegisterSystem;
+import org.terasology.engine.registry.In;
+import org.terasology.genome.GenomeRegistry;
+import org.terasology.genome.component.GenomeComponent;
+import org.terasology.genome.system.SimpleGenomeManager;
+
+/**
+ * Extension system integrating genetics with basic crafting.
+ *
+ * This component system is only loaded if both "Genome" and "BasicCrafting" are enabled.
+ */
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class GenomeCraftingExtensionAuthoritySystem {
+
+    @In
+    private GenomeRegistry genomeRegistry;
+
+    /**
+     * Adds genes to the crafted entity if breeding is possible.
+     * @param event the OnRecipeCrafted event
+     * @param entity the crafted entity which is to be modified
+     */
+    @ReceiveEvent
+    public void onRecipeCraftedEvent(OnRecipeCrafted event, EntityRef entity) {
+        EntityRef[] ingredients = event.getIngredients();
+        if (ingredients.length != 2) {
+            return;
+        }
+
+        if (!(ingredients[0].hasComponent(GenomeComponent.class) || ingredients[1].hasComponent(GenomeComponent.class))) {
+            return;
+        }
+
+        SimpleGenomeManager genomeManager = new SimpleGenomeManager();
+        boolean result = genomeManager.applyBreeding(ingredients[0], ingredients[1], entity);
+        if (entity.hasComponent(GenomeComponent.class)) {
+            GenomeUtil.updateFilling(genomeRegistry, entity);
+        }
+    }
+}

--- a/src/main/java/org/terasology/simpleFarming/systems/GenomeCraftingExtensionAuthoritySystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/GenomeCraftingExtensionAuthoritySystem.java
@@ -19,7 +19,7 @@ import org.terasology.genome.system.SimpleGenomeManager;
  *
  * This component system is only loaded if both "Genome" and "BasicCrafting" are enabled.
  */
-@RegisterSystem(RegisterMode.AUTHORITY)
+@RegisterSystem(value = RegisterMode.AUTHORITY, requiresOptional = {"Genome", "BasicCrafting"})
 public class GenomeCraftingExtensionAuthoritySystem extends BaseComponentSystem {
 
     @In

--- a/src/main/java/org/terasology/simpleFarming/systems/GenomeExtensionAuthoritySystem.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/GenomeExtensionAuthoritySystem.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.simpleFarming.systems;
 
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  *
  * This component system is only loaded if the "Genome" module is active.
  */
-@RegisterSystem(RegisterMode.AUTHORITY)
+@RegisterSystem(value = RegisterMode.AUTHORITY, requiresOptional = "Genome")
 public class GenomeExtensionAuthoritySystem extends BaseComponentSystem {
     private static final Logger LOGGER = LoggerFactory.getLogger(GenomeExtensionAuthoritySystem.class);
 

--- a/src/main/java/org/terasology/simpleFarming/systems/GenomeUtil.java
+++ b/src/main/java/org/terasology/simpleFarming/systems/GenomeUtil.java
@@ -1,0 +1,27 @@
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.simpleFarming.systems;
+
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.genome.GenomeRegistry;
+import org.terasology.genome.component.GenomeComponent;
+import org.terasology.genome.genomeMap.GenomeMap;
+import org.terasology.simpleFarming.events.ModifyFilling;
+import org.terasology.simpleFarming.events.ModifyTint;
+
+public final class GenomeUtil {
+
+    private GenomeUtil() {
+    }
+
+    public static void updateFilling(GenomeRegistry genomeRegistry, EntityRef entity) {
+        GenomeComponent genome = entity.getComponent(GenomeComponent.class);
+        GenomeMap genomeMap = genomeRegistry.getGenomeDefinition(genome.genomeId).getGenomeMap();
+        float fillingModifier = genomeMap.getProperty("filling", genome.genes, Float.class);
+
+        float newFilling = entity.send(new ModifyFilling(fillingModifier)).filling.getValue();
+
+        entity.send(new ModifyTint(newFilling));
+    }
+}


### PR DESCRIPTION
The integration with Genome and BasicCrafting is optional for SimpleFarming.

As a component system can only be loaded properly if all it's dependencies are also active, this means that the combined `GenomeAuthoritySystem` is only loaded if **both** Genome and BasicCrafting are active.

By splitting the authority system into `GenomeExtensionAuthoritySystem` and `GenomeCraftingExtensionAuthoritySystem` each extension system can run with the minimal set of required modules.

- `GenomeExtensionAuthoritySystem` (works if at least Genome is loaded)
- `GenomeCraftingExtensionAuthoritySystem` (works if both Genome and Basic Crafting are loaded)

Fixes #119
Closes #103 
