### PR TITLE
Reformatting annotations of ``SimpleFarming``

### DIFF
--- a/src/test/java/org/terasology/simpleFarming/systems/BushAuthoritySystemTest.java
+++ b/src/test/java/org/terasology/simpleFarming/systems/BushAuthoritySystemTest.java
@@ -6,16 +6,11 @@ import org.joml.Vector3f;
 import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
 import org.terasology.engine.integrationenvironment.TestEventReceiver;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
-import org.terasology.engine.integrationenvironment.jupiter.UseWorldGenerator;
 import org.terasology.engine.logic.common.ActivateEvent;
 import org.terasology.engine.logic.health.DestroyEvent;
 import org.terasology.engine.logic.health.EngineDamageTypes;
@@ -28,14 +23,13 @@ import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockComponent;
 import org.terasology.engine.world.block.BlockManager;
 import org.terasology.simpleFarming.components.BushDefinitionComponent;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-@ExtendWith(MTEExtension.class)
-@UseWorldGenerator("unittest:empty")
-@Dependencies({"SimpleFarming", "CoreAssets"})
-@Tag("MteTest")
+
+@IntegrationEnvironment(dependencies = {"SimpleFarming", "CoreAssets"}, worldGenerator = "unittest:empty")
 public class BushAuthoritySystemTest extends BaseAuthorityTest {
 
     @In

--- a/src/test/java/org/terasology/simpleFarming/systems/PlantAuthoritySystemTest.java
+++ b/src/test/java/org/terasology/simpleFarming/systems/PlantAuthoritySystemTest.java
@@ -6,15 +6,10 @@ import org.joml.Vector3f;
 import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
-import org.terasology.engine.integrationenvironment.jupiter.UseWorldGenerator;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.engine.world.block.Block;
@@ -22,14 +17,12 @@ import org.terasology.engine.world.block.BlockManager;
 import org.terasology.simpleFarming.components.BushDefinitionComponent;
 import org.terasology.simpleFarming.components.BushGrowthStage;
 import org.terasology.simpleFarming.components.SeedDefinitionComponent;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import java.util.Collections;
 
 
-@ExtendWith(MTEExtension.class)
-@UseWorldGenerator("unittest:empty")
-@Dependencies({"SimpleFarming", "CoreAssets"})
-@Tag("MteTest")
+@IntegrationEnvironment(dependencies = {"SimpleFarming", "CoreAssets"}, worldGenerator = "unittest:empty")
 public class PlantAuthoritySystemTest extends BaseAuthorityTest {
 
     /**


### PR DESCRIPTION
Related issue: [#5087](https://github.com/MovingBlocks/Terasology/issues/5087)

The goal of this PR is to replace old annotations in ``BushAuthoritySystemTest`` and ``PlantAuthoritySystemTest``